### PR TITLE
Replace terminaldimension to go-tty to support Windows

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	dimensions "github.com/wayneashleyberry/terminal-dimensions"
+	"github.com/mattn/go-tty"
 )
 
 const defaultWidth uint = 100
@@ -15,7 +15,16 @@ var clearer string
 
 func init() {
 	var err error
-	if terminalWidth, err = dimensions.Width(); err != nil {
+
+	t, err := tty.Open()
+	if err == nil {
+		var width int
+		if width, _, err = t.Size(); err == nil {
+			terminalWidth = uint(width)
+		}
+		t.Close()
+	}
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "couldn't determine the width of the terminal, defaulting to %d", defaultWidth)
 		terminalWidth = defaultWidth
 	}


### PR DESCRIPTION
bar package works well.

![image](https://user-images.githubusercontent.com/10111/59238000-4037cf00-8c37-11e9-8a76-a40e7edb8c39.png)
