### PR TITLE
don't panic in init()

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -24,13 +24,9 @@ func init() {
 		}
 		t.Close()
 	}
-	if err != nil {
+	if err != nil || terminalWidth <= 0 {
 		fmt.Fprintf(os.Stderr, "couldn't determine the width of the terminal, defaulting to %d", defaultWidth)
 		terminalWidth = defaultWidth
-	}
-
-	if terminalWidth <= 0 {
-		panic("the terminal appears to have 0 visible columns")
 	}
 
 	clearer = strings.Repeat(" ", int(terminalWidth)-1)


### PR DESCRIPTION
We're using your `bar` package as part of a small CLI tool. As part of some automatic tests, those are run in an environment with no proper terminal available. 

`panic()`ing in an `init()` method is not recommended, as it is not possible to catch. 